### PR TITLE
Adjust and export interfaces

### DIFF
--- a/src/Stack/index.tsx
+++ b/src/Stack/index.tsx
@@ -1,19 +1,19 @@
 import { StyledFlex } from "./styles.js";
 import {
-  WrapControl,
-  DirectionAlignment,
-  JustifyContent,
-  AlignItem,
-  AlignContent,
+  IStackWrapControl,
+  IStackDirectionAlignment,
+  IStackJustifyContent,
+  IStackAlignItem,
+  IStackAlignContent,
 } from "./props";
 
 interface IStack {
   children?: React.ReactNode;
-  wrap?: WrapControl;
-  direction?: DirectionAlignment;
-  justifyContent?: JustifyContent;
-  alignItems?: AlignItem;
-  alignContent?: AlignContent;
+  wrap?: IStackWrapControl;
+  direction?: IStackDirectionAlignment;
+  justifyContent?: IStackJustifyContent;
+  alignItems?: IStackAlignItem;
+  alignContent?: IStackAlignContent;
   height?: string;
   width?: string;
   gap?: string;

--- a/src/Stack/props.ts
+++ b/src/Stack/props.ts
@@ -15,7 +15,7 @@ const alignContentProperties = [
   "stretch",
   "normal",
 ] as const;
-type AlignContent = (typeof alignContentProperties)[number];
+type IStackAlignContent = (typeof alignContentProperties)[number];
 
 const alignItemsProperties = [
   "baseline",
@@ -32,7 +32,7 @@ const alignItemsProperties = [
   "start",
   "end",
 ] as const;
-type AlignItem = (typeof alignItemsProperties)[number];
+type IStackAlignItem = (typeof alignItemsProperties)[number];
 
 const directionAlignments = [
   "row",
@@ -44,7 +44,7 @@ const directionAlignments = [
   "revert",
   "unset",
 ] as const;
-type DirectionAlignment = (typeof directionAlignments)[number];
+type IStackDirectionAlignment = (typeof directionAlignments)[number];
 
 const justifyContentProperties = [
   "flex-start",
@@ -64,7 +64,7 @@ const justifyContentProperties = [
   "stretch",
   "normal",
 ] as const;
-type JustifyContent = (typeof justifyContentProperties)[number];
+type IStackJustifyContent = (typeof justifyContentProperties)[number];
 
 const wrapControls = [
   "wrap",
@@ -76,7 +76,7 @@ const wrapControls = [
   "unset",
 ] as const;
 
-type WrapControl = (typeof wrapControls)[number];
+type IStackWrapControl = (typeof wrapControls)[number];
 
 const props = {
   children: {
@@ -185,9 +185,9 @@ const props = {
 export { props };
 
 export type {
-  AlignContent,
-  AlignItem,
-  DirectionAlignment,
-  JustifyContent,
-  WrapControl,
+  IStackAlignContent,
+  IStackAlignItem,
+  IStackDirectionAlignment,
+  IStackJustifyContent,
+  IStackWrapControl,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
 export { Stack } from "./Stack";
+export type { IStack } from "./Stack";
+export type {
+  IStackAlignContent,
+  IStackAlignItem,
+  IStackDirectionAlignment,
+  IStackJustifyContent,
+  IStackWrapControl,
+} from "./Stack/props";


### PR DESCRIPTION
The names of the interfaces used by the `<Stack />` component were refactored, as well as how they are exported.